### PR TITLE
Ninja compatibility

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+xtdmake (1.3.0ppa1~xenial) xenial; urgency=medium
+
+  * adds ninja generator compatibility
+
+ -- Xavier MARCELET <xavier@marcelet.com>  Fri, 02 Feb 2018 17:48:44 +0100
+
 xtdmake (1.2.1ppa1~xenial) xenial; urgency=medium
 
   * update documentation

--- a/src/coverage/FindCovRule.cmake
+++ b/src/coverage/FindCovRule.cmake
@@ -83,13 +83,14 @@ else()
         ${l_test_list}
         ${XTDMake_HOME}/coverage/coverage.sh
         COMMAND
-        PROJECT_BINARY_DIR=${PROJECT_BINARY_DIR}
-        CMAKE_CURRENT_BINARY_DIR="${CMAKE_CURRENT_BINARY_DIR}"
-        Lcov_EXECUTABLE="${Lcov_EXECUTABLE}"
-        module="${module}"
-        CMAKE_CURRENT_SOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}"
-        CovRule_EXCLUDE_PATTERNS="${CovRule_EXCLUDE_PATTERNS}"
         ${XTDMake_HOME}/coverage/coverage.sh
+          --module "${module}"
+          --exclude "${CovRule_EXCLUDE_PATTERNS}"
+          --top-bindir "${PROJECT_BINARY_DIR}"
+          --bindir "${CMAKE_CURRENT_BINARY_DIR}"
+          --srcdir "${CMAKE_CURRENT_SOURCE_DIR}"
+          --make-bin "${CMAKE_MAKE_PROGRAM}"
+          --lcov-bin "${Lcov_EXECUTABLE}"
         )
 
       add_custom_command(
@@ -101,6 +102,7 @@ else()
         DEPENDS
         ${CMAKE_CURRENT_BINARY_DIR}/coverage.info
         ${XTDMake_HOME}/coverage/status.py
+        COMMAND mkdir -p ${CovRule_OUTPUT}/
         COMMAND ${Genhtml_EXECUTABLE} -q -o ${CovRule_OUTPUT}/ --function-coverage -t "${module} unit test coverage" --demangle-cpp ${CMAKE_CURRENT_BINARY_DIR}/coverage.info --legend -s
         COMMAND ${XTDMake_HOME}/coverage/lcov_cobertura.py ${CMAKE_CURRENT_BINARY_DIR}/coverage.info -d -o ${CovRule_OUTPUT}/coverage.xml
         COMMAND ${XTDMake_HOME}/coverage/status.py --module ${module}  --input-file=${CovRule_OUTPUT}/coverage.xml --output-file=${CovRule_OUTPUT}/status.json --min-percent=${CovRule_MIN_PERCENT}

--- a/src/coverage/coverage.sh
+++ b/src/coverage/coverage.sh
@@ -1,100 +1,293 @@
 #!/bin/bash
-quiet="-q"
+set -e
 
+g_progName=$(basename $0)
+g_verbose=0
+g_debug=0
+g_module=""
+g_excludePatterns=""
+g_topBinDir=""
+g_binDir=""
+g_srcDir=""
+g_makeProg="$(which make)"
+g_lcovProg="$(which lcov)"
+
+function usage
+{
+  cat - <<EOF
+usage : ${l_progName} [options]
+
+Collects code coverage from module's units-test. In order to get coverage produced by
+only module's unit-tests, the scripts implements a global mutex lock that prevents
+parallel execution different module.
+
+[options]
+     --module     : (required) current module name
+     --exclude    : (required) globing pattern of coverage source files to exclude
+     --top-bindir : (required) project binary directory path
+     --bindir     : (required) module's binary directory path
+     --srcdir     : (required) module's source directory path
+     --make-bin   : (optional) build program path, default ${g_makeProg}
+     --lcov-bin   : (optional) lcov program path, default ${g_lcovProg}
+  -v|--verbose    : (optional) enable lcov verbose mode
+  -d|--debug      : (optional) enable debug mode
+  -h|--help       : (optional) display this message
+EOF
+  exit 1
+}
+
+
+function read_options
+{
+  while true; do
+    case "$1" in
+      --module)
+        g_module=$2;
+        shift 2;;
+      --exclude)
+        g_excludePatterns=$2;
+        shift 2;;
+      --top-bindir)
+        g_topBinDir=$2;
+        shift 2;;
+      --bindir)
+        g_binDir=$2;
+        shift 2;;
+      --srcdir)
+        g_srcDir=$2;
+        shift 2;;
+      --make-bin)
+        g_makeProg=$(which $2);
+        shift 2;;
+      --lcov-bin)
+        g_lcovProg=$(which $2);
+        shift 2;;
+      -v|--verbose)
+        g_verbose=1
+        shift 1;;
+      -d|--debug)
+        g_debug=1
+        shift 1;;
+      -h|--help)
+				usage;;
+      --)
+        shift;
+        break;;
+      *)
+        echo "error: internal problem while parsing options near '$@'"
+        usage;;
+    esac
+  done
+}
+
+function error
+{
+  echo "error : $@"
+  usage
+}
+
+function check_options
+{
+  test ! -z "${g_module}" || \
+      error "invalid empty --module"
+  test ! -z "${g_excludePatterns}" || \
+      error "invalid empty --exclude"
+  test -d "${g_topBinDir}" || \
+      error "invalid --top-bindir='${g_topBinDir}', directory not found"
+  test -d "${g_binDir}" || \
+      error "invalid --bindir='${g_binDir}', directory not found"
+  test -d "${g_srcDir}" || \
+      error "invalid --srcdir='${g_srcDir}', directory not found"
+  test -f "${g_makeProg}" || \
+      error "invalid --make-bin='${g_makeProg}', file not found"
+  test -f "${g_lcovProg}" || \
+      error "invalid --lcov-bin='${g_lcovProg}', file not found"
+}
+
+# aquire mutex, wait until mutex available or timeout reached
 function lock
 {
-  l_timeout=900
-  echo "[${module}-cov] acquiring cov lock..."
+  local l_timeout=900
+  local l_pid=""
+
+  echo "[${g_module}-cov] acquiring cov lock..."
   while true; do
-    if [ ! -f "${PROJECT_BINARY_DIR}/cov.lock" ]; then
-        echo -n "$$" > ${PROJECT_BINARY_DIR}/cov.lock
+    if [ ! -f "${g_topBinDir}/cov.lock" ]; then
+        echo -n "$$" > ${g_topBinDir}/cov.lock
         break;
     else
-      l_pid=$(cat "${PROJECT_BINARY_DIR}/cov.lock")
+      l_pid=$(cat "${g_topBinDir}/cov.lock")
       kill -0 "${l_pid}" 2>/dev/null || {
-        rm -f ${PROJECT_BINARY_DIR}/cov.lock
+        rm -f ${g_topBinDir}/cov.lock
       }
     fi
     l_timeout=$((l_timeout - 1))
     if [ ${l_timeout} -le 0 ]; then
-        echo "unable to aquire lock, giving up"
+        echo "[${g_module}-cov] (pid:$$) unable to aquire lock, giving up"
         exit 1
     fi
     sleep 1
   done
-  echo "[${module}-cov] cov lock acquired"
+  echo "[${g_module}-cov] (pid:$$) cov lock acquired"
 }
 
-
+# release mutex
 function unlock
 {
-  echo "[${module}-cov] releasing cov lock..."
-  rm -f ${PROJECT_BINARY_DIR}/cov.lock
-  echo "[${module}-cov] cov lock released"
+  echo "[${g_module}-cov] (pid:$$) releasing cov lock..."
+  rm -f ${g_topBinDir}/cov.lock
+  echo "[${g_module}-cov] (pid:$$) cov lock released"
 }
 
+# delete from target file matching pattern
+function rm_files
+{
+  local l_target=$1; shift
+  local l_pattern=$1; shift
 
-# export generated gcda to tmp dir, unlock asap
-l_tmp=$(mktemp -d)
+  find ${l_target} -name "${l_pattern}" -exec rm -f \{\} \;
+}
 
-lock
+# copy files from src dir to dest dir that match given pattern
+# and filtering with given exclude
+function copy_files
+{
+  local l_src=$1; shift
+  local l_dst=$1; shift
+  local l_pattern=$1; shift
+  local l_exclude=$1; shift
 
-# delete existing gcda
-find ${CMAKE_CURRENT_BINARY_DIR} \
-     -name '*.gcda' \
-     -exec rm -f \{\} \;
+  find ${l_src} \
+       -name "${l_pattern}" \
+       -and \( ! -wholename "${l_exclude}" \)
 
-echo "[${module}-cov] running tests"
-make ${module}-check-run-forced >/dev/null 2>&1
+  find ${l_src} \
+       -name "${l_pattern}" \
+       -and \( ! -wholename "${l_exclude}" \) \
+       -exec cp --parents \{\} ${l_dst} \;
+}
 
-find ${CMAKE_CURRENT_BINARY_DIR} \
-     -name '*.gcda' \
-     -and \( ! -wholename "*${CovRule_EXCLUDE_PATTERNS}*.gcda" \) \
-     -exec cp --parents \{\} ${l_tmp} \;
+function lcov_args
+{
+  if [ ${g_verbose} -eq 0 ]; then
+      echo "-q"
+  fi
+}
 
-unlock
+# removes gdca files for given directory
+function lcov_zero
+{
+  local l_src=$1; shift
 
+  echo "[${g_module}-cov] (pid:$$) reset coverage data"
+  ${g_lcovProg} $(lcov_args) -z -d "${l_src}"
+}
 
-rm -f \
-   ${CMAKE_CURRENT_BINARY_DIR}/coverage-run.info \
-   ${CMAKE_CURRENT_BINARY_DIR}/coverage-initial.info \
-   ${CMAKE_CURRENT_BINARY_DIR}/coverage.info
+# collect initial coverage information from found .gnco files
+function lcov_initial
+{
+  local l_src=$1; shift
 
+  echo "[${g_module}-cov] (pid:$$) collect initial data"
+  ${g_lcovProg} \
+      $(lcov_args) \
+      -c \
+      -i \
+      -d ${l_src} \
+      -o ${g_binDir}/coverage-initial.info
+}
 
-find ${CMAKE_CURRENT_BINARY_DIR} \
-     -name '*.gcno' \
-     -and \( ! -wholename "*${CovRule_EXCLUDE_PATTERNS}*.gcno" \) \
-     -exec cp --parents \{\} ${l_tmp} \;
+# collect reached code coverage information from generated  .gcda files
+function lcov_collect
+{
+  local l_src=$1; shift
 
+  # -b ${g_binDir}
 
-# collect initial data
-echo "[${module}-cov] collect initial data"
-${Lcov_EXECUTABLE} ${quiet} -c -i \
-                   -d ${l_tmp} \
-                   -o ${CMAKE_CURRENT_BINARY_DIR}/coverage-initial.info 2>&1 | \
-    grep -v 'Note:'
+  echo "[${g_module}-cov] (pid:$$) collecting coverage data"
+  ${g_lcovProg} \
+      $(lcov_args) \
+      -c \
+      -d ${l_src} \
+      -o ${g_binDir}/coverage-run.info || {
+    echo "[${g_module}-cov] (pid:$$) error collecting coverage data"
+    cp ${g_binDir}/coverage-initial.info ${g_binDir}/coverage-run.info
+  }
+}
 
-echo "[${module}-cov] collecting coverage data"
-${Lcov_EXECUTABLE} ${quiet} -c \
-                   -d ${l_tmp} \
-                   -o ${CMAKE_CURRENT_BINARY_DIR}/coverage-run.info || \
-    cp ${CMAKE_CURRENT_BINARY_DIR}/coverage-initial.info \
-       ${CMAKE_CURRENT_BINARY_DIR}/coverage-run.info
+# assemble collected coverage with initial data
+function lcov_assemble
+{
+  echo "[${g_module}-cov] (pid:$$) assembling run and initial data"
+  ${g_lcovProg} \
+      $(lcov_args) \
+      -b ${g_binDir} \
+      -a ${g_binDir}/coverage-initial.info \
+      -a ${g_binDir}/coverage-run.info \
+      -o ${g_binDir}/coverage.info || {
+    echo "[${g_module}-cov] error assembling run and initial data"
+    cp ${g_binDir}/coverage-initial.info ${g_binDir}/coverage.info
+  }
+}
 
-echo "[${module}-cov] assembling run and initial data"
-${Lcov_EXECUTABLE} ${quiet} \
-                   -a ${CMAKE_CURRENT_BINARY_DIR}/coverage-initial.info \
-                   -a ${CMAKE_CURRENT_BINARY_DIR}/coverage-run.info \
-                   -o ${CMAKE_CURRENT_BINARY_DIR}/coverage.info || \
-    cp ${CMAKE_CURRENT_BINARY_DIR}/coverage-initial.info \
-       ${CMAKE_CURRENT_BINARY_DIR}/coverage.info
+# exclude files from collected that don't belongs to basePath directory
+function lcov_filter
+{
+  local l_pattern=$1; shift
+  local l_mode=$1; shift
+  local l_arg=""
 
-echo "[${module}-cov] extracting source directory data"
-${Lcov_EXECUTABLE} ${quiet} \
-                   -e ${CMAKE_CURRENT_BINARY_DIR}/coverage.info \
-                   "${CMAKE_CURRENT_SOURCE_DIR}/*" \
-                   -o ${CMAKE_CURRENT_BINARY_DIR}/coverage.info
+  if [ "${l_mode}" == "extract" ]; then
+      l_arg="-e ${g_binDir}/coverage.info"
+  else
+      l_arg="-r ${g_binDir}/coverage.info"
+  fi
 
+  echo "[${g_module}-cov] (pid:$$) extracting source directory data"
+  ${g_lcovProg} \
+      $(lcov_args) \
+      -b ${g_binDir} \
+      ${l_arg} \
+      "${l_pattern}" \
+      -o ${g_binDir}/coverage.info
+}
 
-# delete tmp dir
-rm -rf ${l_tmp}
+function run_tests
+{
+  echo "[${g_module}-cov] (pid:$$) running tests"
+  ${g_makeProg} -C ${g_topBinDir} ${g_module}-check-run-forced >/dev/null 2>&1
+}
+
+function main
+{
+  if [ ${g_debug} -eq 1 ]; then
+      set -x
+  fi
+
+  rm -f \
+     ${g_binDir}/coverage-run.info \
+     ${g_binDir}/coverage-initial.info \
+     ${g_binDir}/coverage.info
+
+  lcov_initial "${g_binDir}"
+
+  lock
+  lcov_zero    "${g_binDir}"
+  run_tests
+  lcov_collect "${g_binDir}"
+  unlock
+
+  lcov_assemble
+  lcov_filter "${g_srcDir}/*"        "extract"
+  lcov_filter "${g_excludePatterns}" "remove"
+}
+
+l_parseResult=`/usr/bin/getopt -o hvd \
+  --long module:,exclude:,top-bindir:,bindir:,srcdir:,make-bin:,lcov-bin:,verbose,debug,help \
+	-n "${l_progName}" -- "$@"`
+
+eval set -- "${l_parseResult}"
+
+read_options "$@"
+check_options
+main

--- a/src/coverage/coverage.sh
+++ b/src/coverage/coverage.sh
@@ -180,7 +180,7 @@ function lcov_zero
   local l_src=$1; shift
 
   echo "[${g_module}-cov] (pid:$$) reset coverage data"
-  ${g_lcovProg} $(lcov_args) -z -d "${l_src}"
+  ${g_lcovProg} $(lcov_args) -z -d "${l_src}" || true
 }
 
 # collect initial coverage information from found .gnco files
@@ -188,13 +188,16 @@ function lcov_initial
 {
   local l_src=$1; shift
 
-  echo "[${g_module}-cov] (pid:$$) collect initial data"
+  echo "[${g_module}-cov] (pid:$$) collecting initial data"
   ${g_lcovProg} \
       $(lcov_args) \
       -c \
       -i \
       -d ${l_src} \
-      -o ${g_binDir}/coverage-initial.info
+      -o ${g_binDir}/coverage-initial.info || {
+    echo "[${g_module}-cov] error collecting initial data"
+    cp ${g_binDir}/coverage-initial.info ${g_binDir}/coverage.info
+  }
 }
 
 # collect reached code coverage information from generated  .gcda files

--- a/src/doc/FindDocRule.cmake
+++ b/src/doc/FindDocRule.cmake
@@ -178,11 +178,15 @@ else()
     endforeach()
 
     add_custom_target(${module}-doc
-      DEPENDS ${DocRule_OUTPUT}/html/index.html)
-    set_target_properties(${module}-doc
-      PROPERTIES OUTPUT_DIR "${DocRule_OUTPUT}")
+      DEPENDS
+      ${DocRule_OUTPUT}/html/index.html
+      ${DocRule_OUTPUT}/xml/index.xml)
     add_custom_target(${module}-doc-clean
       COMMAND rm -rf ${DocRule_OUTPUT})
+
+    set_target_properties(${module}-doc
+      PROPERTIES OUTPUT_DIR "${DocRule_OUTPUT}")
+
     add_dependencies(doc       ${module}-doc)
     add_dependencies(doc-clean ${module}-doc-clean)
   endfunction()

--- a/src/interface/FindReports.cmake
+++ b/src/interface/FindReports.cmake
@@ -4,7 +4,7 @@ add_custom_target(reports-graph)
 add_custom_target(reports
   DEPENDS doc doc-coverage cloc cppcheck check cov memcheck codedup)
 add_custom_target(reports-clean
-  DEPENDS doc-clean doc-coverage-clean cloc-clean cppcheck-clean check-clean cov-clean memcheck-clean codedup-clean)
+  DEPENDS doc-clean doc-coverage-clean cloc-clean cppcheck-clean check-clean cov-clean memcheck-clean codedup-clean iwyu-clean)
 
 
 function(xtdmake_init_project name directory)

--- a/src/interface/FindReports.cmake
+++ b/src/interface/FindReports.cmake
@@ -78,11 +78,11 @@ endfunction()
 if (DocRule_FOUND)
   add_custom_command(TARGET doc
     POST_BUILD
-    COMMAND $(MAKE) reports-update
+    COMMAND ${CMAKE_MAKE_PROGRAM} reports-update
     VERBATIM)
   add_custom_command(TARGET doc-clean
     POST_BUILD
-    COMMAND $(MAKE) reports-update
+    COMMAND ${CMAKE_MAKE_PROGRAM} reports-update
     VERBATIM)
 endif()
 

--- a/src/interface/FindReports.cmake
+++ b/src/interface/FindReports.cmake
@@ -90,11 +90,11 @@ endif()
 if (DocCoverageRule_FOUND)
   add_custom_command(TARGET doc-coverage
     POST_BUILD
-    COMMAND $(MAKE) reports-update
+    COMMAND ${CMAKE_MAKE_PROGRAM} reports-update
     VERBATIM)
   add_custom_command(TARGET doc-coverage-clean
     POST_BUILD
-    COMMAND $(MAKE) reports-update
+    COMMAND ${CMAKE_MAKE_PROGRAM} reports-update
     VERBATIM)
 endif()
 
@@ -102,11 +102,11 @@ endif()
 if (ClocRule_FOUND)
   add_custom_command(TARGET cloc
     POST_BUILD
-    COMMAND $(MAKE) reports-update
+    COMMAND ${CMAKE_MAKE_PROGRAM} reports-update
     VERBATIM)
   add_custom_command(TARGET cloc-clean
     POST_BUILD
-    COMMAND $(MAKE) reports-update
+    COMMAND ${CMAKE_MAKE_PROGRAM} reports-update
     VERBATIM)
 endif()
 
@@ -114,33 +114,33 @@ endif()
 if (CppcheckRule_FOUND)
   add_custom_command(TARGET cppcheck
     POST_BUILD
-    COMMAND $(MAKE) reports-update
+    COMMAND ${CMAKE_MAKE_PROGRAM} reports-update
     VERBATIM)
   add_custom_command(TARGET cppcheck-clean
     POST_BUILD
-    COMMAND $(MAKE) reports-update
+    COMMAND ${CMAKE_MAKE_PROGRAM} reports-update
     VERBATIM)
 endif()
 
 if (CodeDupRule_FOUND)
   add_custom_command(TARGET codedup
     POST_BUILD
-    COMMAND $(MAKE) reports-update
+    COMMAND ${CMAKE_MAKE_PROGRAM} reports-update
     VERBATIM)
   add_custom_command(TARGET codedup-clean
     POST_BUILD
-    COMMAND $(MAKE) reports-update
+    COMMAND ${CMAKE_MAKE_PROGRAM} reports-update
     VERBATIM)
 endif()
 
 if (IwyuRule_FOUND)
   add_custom_command(TARGET iwyu
     POST_BUILD
-    COMMAND $(MAKE) reports-update
+    COMMAND ${CMAKE_MAKE_PROGRAM} reports-update
     VERBATIM)
   add_custom_command(TARGET iwyu-clean
     POST_BUILD
-    COMMAND $(MAKE) reports-update
+    COMMAND ${CMAKE_MAKE_PROGRAM} reports-update
     VERBATIM)
 endif()
 
@@ -148,32 +148,32 @@ endif()
 if (CheckRule_FOUND)
   add_custom_command(TARGET check
     POST_BUILD
-    COMMAND $(MAKE) reports-update
+    COMMAND ${CMAKE_MAKE_PROGRAM} reports-update
     VERBATIM)
   add_custom_command(TARGET check-clean
     POST_BUILD
-    COMMAND $(MAKE) reports-update
+    COMMAND ${CMAKE_MAKE_PROGRAM} reports-update
     VERBATIM)
 endif()
 
 if (CovRule_FOUND)
   add_custom_command(TARGET cov
     POST_BUILD
-    COMMAND $(MAKE) reports-update
+    COMMAND ${CMAKE_MAKE_PROGRAM} reports-update
     VERBATIM)
   add_custom_command(TARGET cov-clean
     POST_BUILD
-    COMMAND $(MAKE) reports-update
+    COMMAND ${CMAKE_MAKE_PROGRAM} reports-update
     VERBATIM)
 endif()
 
 if (MemcheckRule_FOUND)
   add_custom_command(TARGET memcheck
     POST_BUILD
-    COMMAND $(MAKE) reports-update
+    COMMAND ${CMAKE_MAKE_PROGRAM} reports-update
     VERBATIM)
   add_custom_command(TARGET memcheck-clean
     POST_BUILD
-    COMMAND $(MAKE) reports-update
+    COMMAND ${CMAKE_MAKE_PROGRAM} reports-update
     VERBATIM)
 endif()

--- a/src/interface/FindReports.cmake
+++ b/src/interface/FindReports.cmake
@@ -6,24 +6,33 @@ add_custom_target(reports
 add_custom_target(reports-clean
   DEPENDS doc-clean doc-coverage-clean cloc-clean cppcheck-clean check-clean cov-clean memcheck-clean codedup-clean)
 
+
 function(xtdmake_init_project name directory)
+
+  file(GLOB_RECURSE contribs
+    ${XTDMake_HOME}/interface/contribs/*)
+  foreach(c_file ${contribs})
+    string(REPLACE "${XTDMake_HOME}/interface/contribs" "${directory}/reports/contribs" file "${c_file}")
+    list(APPEND outputs ${file})
+  endforeach()
+
   add_custom_command(
     COMMENT "Installing report interface for ${name}"
     OUTPUT
     ${directory}/reports/menu.html
     ${directory}/reports/index.html
     ${directory}/reports/view.html
-    ${directory}/reports/contribs/
+    ${outputs}
     DEPENDS
     ${XTDMake_HOME}/interface/menu.html
     ${XTDMake_HOME}/interface/index.html
     ${XTDMake_HOME}/interface/view.html
-    ${XTDMake_HOME}/interface/contribs/
+    ${contribs}
     COMMAND mkdir -p ${directory}/reports
     COMMAND cp    ${XTDMake_HOME}/interface/menu.html   ${directory}/reports/
     COMMAND cp    ${XTDMake_HOME}/interface/index.html  ${directory}/reports/
     COMMAND cp    ${XTDMake_HOME}/interface/view.html   ${directory}/reports/
-    COMMAND cp -r ${XTDMake_HOME}/interface/contribs/ ${directory}/reports/
+    COMMAND cp -r ${XTDMake_HOME}/interface/contribs/   ${directory}/reports/
     VERBATIM)
 
   add_custom_command(
@@ -66,6 +75,8 @@ function(xtdmake_init_project name directory)
   add_custom_target(reports-${name}
     DEPENDS ${directory}/reports/index.html
     )
+
+
 
   add_dependencies(reports-update reports-${name}-update)
   add_dependencies(reports-show reports-${name}-show)

--- a/src/iwyu/FindIwyuRule.cmake
+++ b/src/iwyu/FindIwyuRule.cmake
@@ -87,7 +87,7 @@ else()
 
       COMMAND mkdir -p ${IwyuRule_OUTPUT}
       COMMAND ${XTDMake_HOME}/iwyu/analyze.py
-               --build-dir "${CMAKE_CURRENT_BINARY_DIR}"
+               --src-dir "${CMAKE_CURRENT_SOURCE_DIR}"
                --commands "${CMAKE_BINARY_DIR}/compile_commands.json"
                --iwyu-bin "${Iwyu_EXECUTABLE}"
                --exclude "${IwyuRule_EXCLUDE_PATTERN}"

--- a/src/iwyu/analyze.py
+++ b/src/iwyu/analyze.py
@@ -109,7 +109,7 @@ class Worker(threading.Thread):
 class App:
   def __init__(self):
     l_parser = argparse.ArgumentParser()
-    l_parser.add_argument("--build-dir",    action="store",      help ="current module build directory",              required=True)
+    l_parser.add_argument("--src-dir",      action="store",      help ="current module source directory",             required=True)
     l_parser.add_argument("--output-file",  action="store",      help ="output result to given file, '-' for stdout", required=False, default="-")
     l_parser.add_argument("--commands",     action="store",      help ="path to compile commands file",               required=True)
     l_parser.add_argument("--iwyu-bin",     action="store",      help ="include-what-you-use bin path",               required=False, default="include-what-you-use")
@@ -125,9 +125,8 @@ class App:
     l_list    = json.loads(l_content)
     l_res     = []
     for c_item in l_list:
-      l_dir  = c_item["directory"]
       l_file = c_item["file"]
-      if l_dir.startswith(self.build_dir):
+      if l_file.startswith(self.src_dir):
         if not fnmatch.fnmatch(l_file, self.exclude):
           l_res.append(c_item)
     return l_res

--- a/src/iwyu/index.tpl
+++ b/src/iwyu/index.tpl
@@ -160,7 +160,7 @@ ${c_inc.split("//")[0].strip() | h}
                 </thead>
                 <tbody>
                   <%
-                  l_base = items.keys()[0]
+                  l_base = list(items.keys())[0]
                   while len(l_base):
                     l_found=True
                     for c_file in items.keys():
@@ -172,7 +172,7 @@ ${c_inc.split("//")[0].strip() | h}
                       break
                     l_base = "/".join(l_base.split("/")[:-1])
                   %>
-                  % for c_file, c_data in sorted(items.items(), cmp=lambda x,y:cmp(x[0],y[0])):
+                  % for c_file, c_data in sorted(items.items(), key=lambda x: x[0]):
                     <% css="warning" %>
                     % if c_data["errors"] == False:
                       <% css="success" %>

--- a/src/iwyu/status.py
+++ b/src/iwyu/status.py
@@ -5,7 +5,7 @@ import os
 import json
 import argparse
 from mako.template import Template
-
+from mako          import exceptions
 
 l_parser = argparse.ArgumentParser()
 l_parser.add_argument("--module",        action="store", help ="current module name",       required=True)
@@ -21,7 +21,12 @@ l_data    = json.loads(l_content)
 
 l_tplPath  = os.path.join(os.path.dirname(os.path.abspath(__file__)), "index.tpl")
 l_tpl      = Template(filename=l_tplPath)
-l_content  = l_tpl.render(items=l_data)
+
+try:
+  l_content  = l_tpl.render(items=l_data)
+except:
+  print(exceptions.text_error_template().render())
+
 l_htmlFile = open(l_result.output_html, "w")
 l_htmlFile.write(l_content)
 

--- a/src/memcheck/FindMemcheckRule.cmake
+++ b/src/memcheck/FindMemcheckRule.cmake
@@ -67,6 +67,13 @@ else()
         execute_process(COMMAND touch ${CMAKE_CURRENT_BINARY_DIR}/memcheck.success)
       endif()
 
+      add_custom_command(
+        COMMENT "test"
+        DEPENDS ${XTDMake_HOME}/memcheck/FindMemcheckRule.cmake
+        OUTPUT  ${CMAKE_CURRENT_BINARY_DIR}/memcheck.success
+        COMMAND test -f ${CMAKE_CURRENT_BINARY_DIR}/memcheck.success || touch ${CMAKE_CURRENT_BINARY_DIR}/memcheck.success
+        )
+
       if (Valgrind_VERSION VERSION_LESS 3.9.0)
         add_custom_target(${module}-memcheck-ut-${c_test}
           COMMAND valgrind
@@ -94,36 +101,40 @@ else()
           ${MemcheckRule_EXTRA_ARGS}
           --
           ./${c_test} ${c_test_args} > /dev/null 2>&1 || true
+          COMMAND grep -q "<kind>" ${CMAKE_CURRENT_BINARY_DIR}/${c_test}.memcheck.xml && rm -f ${CMAKE_CURRENT_BINARY_DIR}/memcheck.success || true
           VERBATIM)
       else()
         add_custom_target(${module}-memcheck-ut-${c_test}
           COMMAND valgrind
-          --tool=memcheck
-          --leak-check=full
-          --show-leak-kinds=all
-          --num-callers=500
-          --show-reachable=no
-          --gen-suppressions=all
-          ${l_supprs}
-          ${MemcheckRule_EXTRA_ARGS}
-          --
-          ./${c_test} ${c_test_args}
+            --tool=memcheck
+            --leak-check=full
+            --show-leak-kinds=all
+            --num-callers=500
+            --show-reachable=no
+            --gen-suppressions=all
+            ${l_supprs}
+            ${MemcheckRule_EXTRA_ARGS}
+            --
+            ./${c_test} ${c_test_args}
           VERBATIM)
         add_custom_command(
           COMMENT "Performing memory analysis for ${module} : ${c_test}"
-          OUTPUT  ${CMAKE_CURRENT_BINARY_DIR}/${c_test}.memcheck.xml
+          OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${c_test}.memcheck.xml
           DEPENDS ${c_test} ${MemcheckRule_SUPPRESSIONS} ${CMAKE_CURRENT_BINARY_DIR}/memcheck.success
-          COMMAND valgrind
-          --tool=memcheck
-          --leak-check=full
-          --show-leak-kinds=all
-          --num-callers=500
-          --show-reachable=no
-          --xml=yes --xml-file=${CMAKE_CURRENT_BINARY_DIR}/${c_test}.memcheck.xml
-          ${l_supprs}
-          ${MemcheckRule_EXTRA_ARGS}
-          --
-          ./${c_test} ${c_test_args} > /dev/null 2>&1 || true
+          COMMAND
+          valgrind
+              --tool=memcheck
+              --leak-check=full
+              --show-leak-kinds=all
+              --num-callers=500
+              --show-reachable=no
+              --xml=yes
+              --xml-file=${CMAKE_CURRENT_BINARY_DIR}/${c_test}.memcheck.xml
+              ${l_supprs}
+              ${MemcheckRule_EXTRA_ARGS}
+              --
+              ./${c_test} ${c_test_args} > /dev/null 2>&1 || true
+          COMMAND grep -q "<kind>" ${CMAKE_CURRENT_BINARY_DIR}/${c_test}.memcheck.xml && rm -f ${CMAKE_CURRENT_BINARY_DIR}/memcheck.success || true
           VERBATIM)
       endif()
 
@@ -137,7 +148,6 @@ else()
       ${MemcheckRule_OUTPUT}/memcheck.json
       ${MemcheckRule_OUTPUT}/index.html
       ${MemcheckRule_OUTPUT}/status.json
-      ${CMAKE_CURRENT_BINARY_DIR}/memcheck.success
       DEPENDS
       ${l_depends}
       ${XTDMake_HOME}/memcheck/readfiles.py
@@ -145,7 +155,7 @@ else()
       ${XTDMake_HOME}/memcheck/index.html
       ${XTDMake_HOME}/memcheck/status.py
       COMMAND mkdir -p ${MemcheckRule_OUTPUT}
-      COMMAND ${XTDMake_HOME}/memcheck/readfiles.py ${l_depends} > ${MemcheckRule_OUTPUT}/memcheck.json || touch ${CMAKE_CURRENT_BINARY_DIR}/memcheck.success
+      COMMAND ${XTDMake_HOME}/memcheck/readfiles.py ${l_depends} > ${MemcheckRule_OUTPUT}/memcheck.json || true
       COMMAND echo -n "var g_data = " > ${MemcheckRule_OUTPUT}/memcheck.js
       COMMAND cat ${MemcheckRule_OUTPUT}/memcheck.json >> ${MemcheckRule_OUTPUT}/memcheck.js
       COMMAND echo -n ";" >> ${MemcheckRule_OUTPUT}/memcheck.js

--- a/src/memcheck/FindMemcheckRule.cmake
+++ b/src/memcheck/FindMemcheckRule.cmake
@@ -137,6 +137,7 @@ else()
       ${MemcheckRule_OUTPUT}/memcheck.json
       ${MemcheckRule_OUTPUT}/index.html
       ${MemcheckRule_OUTPUT}/status.json
+      ${CMAKE_CURRENT_BINARY_DIR}/memcheck.success
       DEPENDS
       ${l_depends}
       ${XTDMake_HOME}/memcheck/readfiles.py

--- a/tests/Dockerfile.precise
+++ b/tests/Dockerfile.precise
@@ -28,7 +28,7 @@ RUN echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true
 RUN apt-get update -y && apt-get install -y oracle-java8-installer
 RUN wget -O /usr/bin/cloc 'https://github.com/AlDanial/cloc/releases/download/v1.70/cloc-1.70.pl'
 RUN chmod +x /usr/bin/cloc
-RUN pip install coverxygen
+RUN pip install coverxygen --index-url=https://pypi.python.org/simple
 RUN wget -O /tmp/pmd-bin-5.7.0.zip 'https://github.com/pmd/pmd/releases/download/pmd_releases%2F5.7.0/pmd-bin-5.7.0.zip'
 RUN unzip -d /usr/share/ /tmp/pmd-bin-5.7.0.zip
 RUN  mkdir -p /env

--- a/tests/Dockerfile.trusty
+++ b/tests/Dockerfile.trusty
@@ -27,10 +27,12 @@ RUN apt-get install -y software-properties-common
 RUN apt-add-repository -y ppa:webupd8team/java
 RUN echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" | debconf-set-selections
 RUN apt-get update -y && apt-get install -y oracle-java8-installer
-RUN pip install coverxygen
+RUN pip install coverxygen --index-url=https://pypi.python.org/simple
 RUN wget -O /tmp/pmd-bin-5.7.0.zip https://github.com/pmd/pmd/releases/download/pmd_releases%2F5.7.0/pmd-bin-5.7.0.zip
 RUN unzip -d /usr/share/ /tmp/pmd-bin-5.7.0.zip
 RUN  mkdir -p /env
+ADD https://github.com/ninja-build/ninja/releases/download/v1.5.1/ninja-linux.zip .
+RUN unzip ninja-linux.zip && mv ninja /usr/bin/
 COPY ./src /env/src
 COPY ./tests /env/tests
 COPY ./CMakeLists.txt /env/CMakeLists.txt

--- a/tests/Dockerfile.xenial
+++ b/tests/Dockerfile.xenial
@@ -19,8 +19,8 @@ RUN apt-get update -y && \
             openjdk-8-jre \
             wget
 
-RUN apt-get install -y rcs unzip
-RUN pip install coverxygen
+RUN apt-get install -y rcs unzip ninja-build
+RUN pip install coverxygen --index-url=https://pypi.python.org/simple
 RUN wget -O /tmp/pmd-bin-5.7.0.zip https://github.com/pmd/pmd/releases/download/pmd_releases%2F5.7.0/pmd-bin-5.7.0.zip
 RUN unzip -d /usr/share/ /tmp/pmd-bin-5.7.0.zip
 RUN  mkdir -p /env

--- a/tests/build
+++ b/tests/build
@@ -3,6 +3,7 @@
 l_rootdir=$(dirname $(dirname $(readlink -m $0)))
 l_srcdir=$1
 l_buildType=$2
+l_generator=$3
 l_dir=$(mktemp -d)
 VERBOSE=""
 
@@ -20,19 +21,25 @@ if [ "${l_buildType}" == "Debug" ]; then
 fi
 
 cd ${l_dir}
-cmake "${l_srcdir}" -DCMAKE_BUILD_TYPE=${l_buildType} -DCMAKE_PREFIX_PATH=${l_rootdir}/src
+
+if [ ${l_generator} == "ninja" ]; then
+    cmake "${l_srcdir}" -DCMAKE_BUILD_TYPE=${l_buildType} -DCMAKE_PREFIX_PATH=${l_rootdir}/src -G Ninja -DCMAKE_MAKE_PROGRAM=/usr/bin/ninja
+else
+    cmake "${l_srcdir}" -DCMAKE_BUILD_TYPE=${l_buildType} -DCMAKE_PREFIX_PATH=${l_rootdir}/src
+fi
+
 if [ $? -ne 0 ]; then
     echo "error: failed to initialize buildsystem"
     exit 1
 fi
 
-make  -j4 ${VERBOSE}
+${l_generator}  -j4 ${VERBOSE}
 if [ $? -ne 0 ]; then
     echo "error: failed to compile"
     exit 1
 fi
 
-make reports -j4  ${VERBOSE}
+${l_generator} reports -j4  ${VERBOSE}
 if [ $? -ne 0 ]; then
     echo "error: failed to generate reports"
     exit 1
@@ -47,7 +54,7 @@ done
 
 
 mkdir -p ${l_dir}/_tmp
-DESTDIR=${l_dir}/_tmp make install  ${VERBOSE}
+DESTDIR=${l_dir}/_tmp ${l_generator} install  ${VERBOSE}
 l_files=(lib/libp1m1.a lib/libp1m1.a lib/libp1m1.so.0.1.1 lib/libp1m1.so.0 lib/libp1m1.so)
 for c_file in $(echo ${l_files[@]}); do
   if [ ! -f "${l_dir}/_tmp/usr/local/${c_file}" ]; then
@@ -90,14 +97,14 @@ cat ${l_dir}/reports/check/m1/tests.xml | grep -q tMyTest || {
 # check check has incremental build
 l_mtime1=$(stat ${l_dir}/reports/check/m1/tests.xml | grep Modify | cut -d' ' -f2-3)
 touch ${l_srcdir}/m1/unit/TestCode.cc
-make check -j4
+${l_generator} check -j4
 l_mtime2=$(stat ${l_dir}/reports/check/m1/tests.xml | grep Modify | cut -d' ' -f2-3)
 if [ "${l_mtime1}" = "${l_mtime2}" ]; then
     echo "error : check target is not incremental"
     exit 1
 fi
 
-make  clean -j4  ${VERBOSE}
+${l_generator}  clean -j4  ${VERBOSE}
 if [ $? -ne 0 ]; then
     echo "error: failed to clean build tree"
     exit 1

--- a/tests/distro
+++ b/tests/distro
@@ -7,6 +7,10 @@ l_testDir=$(dirname $(readlink -m $0))
 
 cd $(dirname ${l_testDir})
 docker build -t xtdmake-test-${l_distro} -f tests/Dockerfile.${l_distro} .
-docker run -ti --rm=true xtdmake-test-${l_distro} /env/tests/build /env/tests/default Debug
-docker run -ti --rm=true xtdmake-test-${l_distro} /env/tests/build /env/tests/default Release
+docker run -ti --rm=true xtdmake-test-${l_distro} /env/tests/build /env/tests/default Debug make
+docker run -ti --rm=true xtdmake-test-${l_distro} /env/tests/build /env/tests/default Release make
+if [ ${l_distro} != "precise" ]; then
+    docker run -ti --rm=true xtdmake-test-${l_distro} /env/tests/build /env/tests/default Debug ninja
+    docker run -ti --rm=true xtdmake-test-${l_distro} /env/tests/build /env/tests/default Release ninja
+fi
 


### PR DESCRIPTION
This is an experimental branch that aims to support Ninja build in XTDMake as requested in issue #31 


## Working tips

* install ninja bash completion
```
wget https://raw.githubusercontent.com/ninja-build/ninja/master/misc/bash-completion | \
sudo tee /usr/share/bash-completion/completions/ninja
```

## Todo

### Step 1

* [x] base build
* [x] check
  * [x] overall
  * [x] per-module
  * [x] per-test
* [x] cloc
  * [x] overall
  * [x] per-module
* [x] codedup
  * [x] overall
  * [x] per-module
* [x] cppcheck
  * [x] overall
  * [x] per-module
* [x] doc
  * [x] overall
  * [x] per-module
* [x] cov
  * [x] overall
  * [x] per-module
* [x] doc-coverage
  * [x] overall
  * [x] per-module
* [x] iwyu
  * [x] overall
  * [x] per-module
* [x] memcheck
  * [x] overall
  * [x] per-module
  * [x] per-test
* [x] clean

### Step 2

* [x] overall reports generations
* [x] integration of acceptance tests

### Step 3
* [x] make retro-compatibility
* [x] trusty compatibility
* [ ] ~~precise compatibility~~ (cmake's version dosent support ninja generator)

### Bench

* make
```
$ make clean
$ time make reports -j16

real    2m11.474s
user    11m26.980s
sys     0m37.924s
```

* ninja
```
$ ninja clean
$ time ninja reports -j16

real    2m5.421s
user    11m18.708s
sys     0m37.308s
```
